### PR TITLE
Mathjax support

### DIFF
--- a/_includes/mathjax.html
+++ b/_includes/mathjax.html
@@ -1,0 +1,3 @@
+  <script type="text/javascript" async
+  src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML">
+  </script>

--- a/session-de/session-de-methods.md
+++ b/session-de/session-de-methods.md
@@ -1,3 +1,5 @@
+{% include mathjax.html %}
+
 Differential expression methods
 ================
 
@@ -127,7 +129,8 @@ al. 2011).
 #### zero inflated NB
 
 ![](session-de-files/figures/dist-zero-inflated-NB-1.png)<!-- -->
-\[\mu=mu*(1-d)\] \[\delta^2=\mu*(1-d)*(1+d*\mu+\mu/size)\]
+$$mu=mu*(1-d)$$
+$$delta^2=mu*(1-d)*(1+d*mu+mu/size)$$
 
 *d*, dropout rate; dropout rate of a gene is strongly correlated with
 the mean expression of the gene. Different zero-inflated negative


### PR DESCRIPTION
This PR adds support for rendering mathematical equations using Mathjax. An example equation is included in `session-de/session-de-methods.md`.